### PR TITLE
[ADD] EFD/Reinf - v.1.03.02

### DIFF
--- a/pysped/efdreinf/leiaute/evtInfoContribuinte_10302.py
+++ b/pysped/efdreinf/leiaute/evtInfoContribuinte_10302.py
@@ -69,6 +69,7 @@ class Contato(XMLNFe):
         self.nmCtt = TagCaracter(nome='nmCtt', tamanho=[1, 70], raiz='//Reinf/evtInfoContri/infoContri/infoCadastro/contato', namespace=NAMESPACE_EFDREINF, namespace_obrigatorio=False)
         self.cpfCtt = TagCaracter(nome='cpfCtt', tamanho=[1, 11], raiz='//Reinf/evtInfoContri/infoContri/infoCadastro/contato', namespace=NAMESPACE_EFDREINF, namespace_obrigatorio=False)
         self.foneFixo = TagCaracter(nome='foneFixo', tamanho=[1, 11], raiz='//Reinf/evtInfoContri/infoContri/infoCadastro/contato', namespace=NAMESPACE_EFDREINF, namespace_obrigatorio=False, obrigatorio=False)
+        self.foneCel = TagCaracter(nome='foneCel', tamanho=[1, 11], raiz='//Reinf/evtInfoContri/infoContri/infoCadastro/contato', namespace=NAMESPACE_EFDREINF, namespace_obrigatorio=False, obrigatorio=False)
         self.email = TagCaracter(nome='email', tamanho=[1, 11], raiz='//Reinf/evtInfoContri/infoContri/infoCadastro/contato', namespace=NAMESPACE_EFDREINF, namespace_obrigatorio=False, obrigatorio=False)
 
     def get_xml(self):
@@ -77,6 +78,7 @@ class Contato(XMLNFe):
         xml += self.nmCtt.xml
         xml += self.cpfCtt.xml
         xml += self.foneFixo.xml
+        xml += self.foneCel.xml
         xml += self.email.xml
         xml += '</contato>'
         return xml
@@ -86,6 +88,7 @@ class Contato(XMLNFe):
             self.nmCtt.xml = arquivo
             self.cpfCtt.xml = arquivo
             self.foneFixo.xml = arquivo
+            self.foneCel.xml = arquivo
             self.email.xml = arquivo
         return True
 

--- a/pysped/efdreinf/leiaute/soap_10100.py
+++ b/pysped/efdreinf/leiaute/soap_10100.py
@@ -148,7 +148,7 @@ class SOAPConsulta(XMLNFe):
         xml +=         '<sped:ConsultaInformacoesConsolidadas>'
         xml +=             '<sped:tipoInscricaoContribuinte>%s</sped:tipoInscricaoContribuinte>' % self.tipoInscricaoContribuinte
         xml +=             '<sped:numeroInscricaoContribuinte>%s</sped:numeroInscricaoContribuinte>' % self.numeroInscricaoContribuinte
-        xml +=             '<sped:numeroProtocoloFechamento>%s</sped:numeroProtocoloFechamento>' % self.numeroProtocoloFechamento
+        xml +=             '<sped:numeroReciboFechamento>%s</sped:numeroReciboFechamento>' % self.numeroProtocoloFechamento
         xml +=         '</sped:ConsultaInformacoesConsolidadas>'
         xml +=     '</soapenv:Body>'
         xml += '</soapenv:Envelope>'

--- a/pysped/efdreinf/leiaute/soap_10100.py
+++ b/pysped/efdreinf/leiaute/soap_10100.py
@@ -148,7 +148,7 @@ class SOAPConsulta(XMLNFe):
         xml +=         '<sped:ConsultaInformacoesConsolidadas>'
         xml +=             '<sped:tipoInscricaoContribuinte>%s</sped:tipoInscricaoContribuinte>' % self.tipoInscricaoContribuinte
         xml +=             '<sped:numeroInscricaoContribuinte>%s</sped:numeroInscricaoContribuinte>' % self.numeroInscricaoContribuinte
-        xml +=             '<sped:numeroReciboFechamento>%s</sped:numeroReciboFechamento>' % self.numeroProtocoloFechamento
+        xml +=             '<sped:numeroProtocoloFechamento>%s</sped:numeroProtocoloFechamento>' % self.numeroProtocoloFechamento
         xml +=         '</sped:ConsultaInformacoesConsolidadas>'
         xml +=     '</soapenv:Body>'
         xml += '</soapenv:Envelope>'


### PR DESCRIPTION
Este PR adiciona as funcionalidades do layout v.1.03.02 da EFD/Reinf na pysped para os seguintes registros:

R-1000
R-2010
R-2099
R-5001
R-5011

Demais registros ainda pendentes e serão objeto de um PR futuro.