### PR TITLE
[FIX] Correção dos métodos gera_id dos eventos S-2300, S-2306 e S-2399

### DIFF
--- a/pysped/esocial/leiaute/evtTSVAltContr_20402.py
+++ b/pysped/esocial/leiaute/evtTSVAltContr_20402.py
@@ -494,11 +494,14 @@ class S2306(XMLNFe):
         #OBS.: No caso de pessoas jurídicas, o CNPJ informado deverá conter 8 ou 14 posições de
         #acordo com o enquadramento do contribuinte para preenchimento do campo {ideEmpregador/nrInsc} do evento S-1000, completando-se com zeros à direita, se necessário.
 
+        if not sequencia:
+            sequencia=1
+
         id_evento = 'ID'
         id_evento += self.tpInsc
         id_evento += self.nrInsc[0:8] + '000000'
         id_evento += data_hora
-        id_evento += str(1).zfill(5)
+        id_evento += str(sequencia).zfill(5)
 
         # Define o Id
         #

--- a/pysped/esocial/leiaute/evtTSVInicio_20402.py
+++ b/pysped/esocial/leiaute/evtTSVInicio_20402.py
@@ -1168,11 +1168,14 @@ class S2300(XMLNFe):
         #OBS.: No caso de pessoas jurídicas, o CNPJ informado deverá conter 8 ou 14 posições de
         #acordo com o enquadramento do contribuinte para preenchimento do campo {ideEmpregador/nrInsc} do evento S-1000, completando-se com zeros à direita, se necessário.
 
+        if not sequencia:
+            sequencia=1
+
         id_evento = 'ID'
         id_evento += self.tpInsc
         id_evento += self.nrInsc[0:8] + '000000'
         id_evento += data_hora
-        id_evento += str(1).zfill(5)
+        id_evento += str(sequencia).zfill(5)
 
         # Define o Id
         #

--- a/pysped/esocial/leiaute/evtTSVTermino_20402.py
+++ b/pysped/esocial/leiaute/evtTSVTermino_20402.py
@@ -505,11 +505,14 @@ class S2399(XMLNFe):
         #OBS.: No caso de pessoas jurídicas, o CNPJ informado deverá conter 8 ou 14 posições de
         #acordo com o enquadramento do contribuinte para preenchimento do campo {ideEmpregador/nrInsc} do evento S-1000, completando-se com zeros à direita, se necessário.
 
+        if not sequencia:
+            sequencia=1
+
         id_evento = 'ID'
         id_evento += self.tpInsc
         id_evento += self.nrInsc[0:8] + '000000'
         id_evento += data_hora
-        id_evento += str(1).zfill(5)
+        id_evento += str(sequencia).zfill(5)
 
         # Define o Id
         #


### PR DESCRIPTION
Os IDs dos eventos estavam sendo criados sem levar em consideração a sequencia, o que causava duplicidade de IDs durante a transmissão para lotes com mais de um evento deste grupo dentro do lote.